### PR TITLE
Test Coverage for Countdown

### DIFF
--- a/PicIt.xcodeproj/project.pbxproj
+++ b/PicIt.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		D7CBAC7D282462EA00B9B9A0 /* ReadyIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7CBAC79282462EA00B9B9A0 /* ReadyIndicatorView.swift */; };
 		D7CBAC7E282462EA00B9B9A0 /* NotReadyIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7CBAC7A282462EA00B9B9A0 /* NotReadyIndicatorView.swift */; };
 		D7CBAC7F282462EA00B9B9A0 /* InUseIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7CBAC7B282462EA00B9B9A0 /* InUseIndicatorView.swift */; };
+		D7CBAC822825B87700B9B9A0 /* CountdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7CBAC812825B87700B9B9A0 /* CountdownTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -108,6 +109,7 @@
 		D7CBAC79282462EA00B9B9A0 /* ReadyIndicatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadyIndicatorView.swift; sourceTree = "<group>"; };
 		D7CBAC7A282462EA00B9B9A0 /* NotReadyIndicatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotReadyIndicatorView.swift; sourceTree = "<group>"; };
 		D7CBAC7B282462EA00B9B9A0 /* InUseIndicatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InUseIndicatorView.swift; sourceTree = "<group>"; };
+		D7CBAC812825B87700B9B9A0 /* CountdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountdownTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -199,6 +201,7 @@
 		D74E270727AC2F1700992242 /* PicItTests */ = {
 			isa = PBXGroup;
 			children = (
+				D7CBAC802825B84C00B9B9A0 /* Model */,
 				D74E270827AC2F1700992242 /* PicItTests.swift */,
 			);
 			path = PicItTests;
@@ -261,6 +264,14 @@
 				D7CBAC7B282462EA00B9B9A0 /* InUseIndicatorView.swift */,
 			);
 			path = Indicators;
+			sourceTree = "<group>";
+		};
+		D7CBAC802825B84C00B9B9A0 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				D7CBAC812825B87700B9B9A0 /* CountdownTests.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -457,6 +468,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D74E270927AC2F1700992242 /* PicItTests.swift in Sources */,
+				D7CBAC822825B87700B9B9A0 /* CountdownTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PicIt.xcodeproj/xcuserdata/dev.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/PicIt.xcodeproj/xcuserdata/dev.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -10,5 +10,23 @@
 			<integer>0</integer>
 		</dict>
 	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>D74E26F327AC2F1600992242</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>D74E270327AC2F1700992242</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>D74E270D27AC2F1700992242</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/PicIt/Model/CameraModel.swift
+++ b/PicIt/Model/CameraModel.swift
@@ -27,7 +27,7 @@ class AvoidStateChange {
 typealias PhotoChangeCompletion = (Bool, Error?) -> Void
 
 protocol CameraModelDependenciesProtocol {
-    var countdownDefaults: CountdownDefaultsProtocol { get }
+    var countdownDefaults: CountdownDependenciesProtocol { get }
     var countdown: Countdown { get }
     var settings: Settings { get }
     var service: CameraService { get }
@@ -41,7 +41,7 @@ extension CameraModel {
         // We can use this as a way to "reset" those dependencies while keeping the model state
         public static func serviceProvider() -> CameraService { CameraService() }
         public static func settingsProvider() -> Settings { Settings() }
-        public let countdownDefaults: CountdownDefaultsProtocol = Self.CountdownDefaults()
+        public let countdownDefaults: CountdownDependenciesProtocol = Self.CountdownDefaults()
         public let countdown = Countdown()
         public let settings = Self.settingsProvider()
         public let service = Self.serviceProvider()
@@ -50,7 +50,7 @@ extension CameraModel {
         // 1. Allows the usage of Self
         // 2. Avoids polluting the CameraModel (or higher) namespace with a very specific use case.
         // swiftlint:disable:next nesting
-        struct CountdownDefaults: CountdownDefaultsProtocol {
+        struct CountdownDefaults: CountdownDependenciesProtocol {
             let referenceTimeProvider = { Date().timeIntervalSince1970 }
             let countdownFrom = Double(Settings.countdownStart)
             let interval = PicItSetting.interval

--- a/PicIt/Model/CameraModel.swift
+++ b/PicIt/Model/CameraModel.swift
@@ -54,7 +54,7 @@ extension CameraModel {
             let referenceTimeProvider = { Date().timeIntervalSince1970 }
             let countdownFrom = Double(Settings.countdownStart)
             let interval = PicItSetting.interval
-            let countdownPublisher = TimerPublishers().countdownPublisher
+            let countdownPublisherClosure = TimerPublishers().countdownPublisher
         }
     }
 }
@@ -228,7 +228,9 @@ final class CameraModel: ObservableObject {
     }
     
     func countdownStop() {
-        countdown.stop()
+        DispatchQueue.main.async {
+            self.countdown.stop()
+        }
     }
 
     func cameraAction() {

--- a/PicIt/Model/CameraModel.swift
+++ b/PicIt/Model/CameraModel.swift
@@ -54,6 +54,7 @@ extension CameraModel {
             let referenceTimeProvider = { Date().timeIntervalSince1970 }
             let countdownFrom = Double(Settings.countdownStart)
             let interval = PicItSetting.interval
+            let countdownPublisher = TimerPublishers().countdownPublisher
         }
     }
 }

--- a/PicIt/Model/Countdown.swift
+++ b/PicIt/Model/Countdown.swift
@@ -51,15 +51,16 @@ class Countdown: ObservableObject {
     static let initialCountdownTime = 0.0
     
     @Published private(set) var time = Countdown.initialCountdownTime
-    @Published private(set) var state: CountdownState = .ready
+    @Published private(set) var state: CountdownState
     
     private var cancellable: AnyCancellable?
     private var dependencies: CountdownDependenciesProtocol
     
     private var countdownPublisher: CountdownPublisherClosure
     
-    init(_ deps: CountdownDependenciesProtocol = CountdownDependencies()) {
+    init(_ deps: CountdownDependenciesProtocol = CountdownDependencies(), initialState: CountdownState = .ready) {
         self.dependencies = deps
+        self.state = initialState
         self.countdownPublisher = deps.countdownPublisherClosure // syntactic sugar
         Self.log.debug("Countdown Initialized")
     }
@@ -75,6 +76,7 @@ class Countdown: ObservableObject {
             Self.log.warning("Resetting from an undefined state")
             updateState(.ready)
         }
+        time = Countdown.initialCountdownTime
     }
     
     func start(_ countdownFrom: Double? = nil,

--- a/PicIt/Model/Countdown.swift
+++ b/PicIt/Model/Countdown.swift
@@ -6,7 +6,7 @@ import SwiftUI
 import os.log
 
 typealias ReferenceTimeProvider = () -> TimeInterval
-typealias IntervalMapPublisherClosure = (CountdownPublisherArgsProtocol) -> IntervalMapPublisher
+typealias IntervalMapPublisherClosure = (CountdownPublisherArgsProtocol) -> AnyPublisher<Double, Never>
 
 enum CountdownState: CaseIterable {
     case ready
@@ -17,7 +17,7 @@ enum CountdownState: CaseIterable {
     case undefined
 }
 
-protocol CountdownDefaultsProtocol {
+protocol CountdownDependenciesProtocol {
     var referenceTimeProvider: ReferenceTimeProvider { get }
     var countdownFrom: Double { get }
     var interval: TimeInterval { get }
@@ -26,7 +26,7 @@ protocol CountdownDefaultsProtocol {
 
 // In most cases the client should be providing the defaults, but
 // these fallbacks can provide a starting point and guide.
-struct CountdownFallbackDefaults: CountdownDefaultsProtocol {
+struct CountdownDependencies: CountdownDependenciesProtocol {
     let referenceTimeProvider = { Date().timeIntervalSince1970 }
     let countdownFrom = 5.0
     let interval = 0.5
@@ -51,11 +51,11 @@ class Countdown: ObservableObject {
     @Published private(set) var state: CountdownState = .undefined
     
     private var cancellable: AnyCancellable?
-    private var defaults: CountdownDefaultsProtocol
+    private var defaults: CountdownDependenciesProtocol
     
     private var countdownPublisher: IntervalMapPublisherClosure
     
-    init(defaults: CountdownDefaultsProtocol = CountdownFallbackDefaults()) {
+    init(defaults: CountdownDependenciesProtocol = CountdownDependencies()) {
         self.defaults = defaults
         self.countdownPublisher = defaults.countdownPublisher // syntactic sugar
         state = .ready

--- a/PicIt/Model/Countdown.swift
+++ b/PicIt/Model/Countdown.swift
@@ -85,7 +85,7 @@ class Countdown: ObservableObject {
         }
     }
     
-    // Basically start, but with a cleaner type signature that uses the ,
+    // Basically start, but with a cleaner type signature
     // instead of (TimeInterval, TimeInterval, Double) -> Void, it is () -> Void
     func restart() {
         start()

--- a/PicIt/Model/TimerPublishers.swift
+++ b/PicIt/Model/TimerPublishers.swift
@@ -5,7 +5,12 @@ import Combine
 typealias ConnectedTimerPublisher = Publishers.Autoconnect<Timer.TimerPublisher>
 typealias IntervalPublisher = Publishers.MapKeyPath<ConnectedTimerPublisher, TimeInterval>
 typealias IntervalMapPublisher = Publishers.Map<IntervalPublisher, TimeInterval>
-typealias IntervalMapPublisherClosure = (TimeInterval) -> IntervalMapPublisher
+
+protocol CountdownPublisherArgsProtocol {
+    var countdownFrom: Double { get }
+    var referenceTime: TimeInterval { get }
+    var interval: TimeInterval? { get }
+}
 
 struct TimerPublishers {
     static let defaultInterval = 0.5
@@ -27,10 +32,11 @@ struct TimerPublishers {
     }
     
     // Converts an elapsedTime into a countdown timer, given `countdownFrom`
-    func countdownPublisher(countdownFrom: Double, referenceTime: TimeInterval, interval: TimeInterval = defaultInterval) -> IntervalMapPublisher {
-        return self.elapsedPublisherClosure(referenceTime: referenceTime, interval: interval)
+    func countdownPublisher(args: CountdownPublisherArgsProtocol) -> IntervalMapPublisher {
+        let interval = args.interval ?? Self.defaultInterval
+        return self.elapsedPublisherClosure(referenceTime: args.referenceTime, interval: interval)
             .map({elapsedTime in
-                return countdownFrom - elapsedTime
+                return args.countdownFrom - elapsedTime
             })
     }
 }

--- a/PicIt/Model/TimerPublishers.swift
+++ b/PicIt/Model/TimerPublishers.swift
@@ -2,10 +2,6 @@
 import Foundation
 import Combine
 
-typealias ConnectedTimerPublisher = Publishers.Autoconnect<Timer.TimerPublisher>
-typealias IntervalPublisher = Publishers.MapKeyPath<ConnectedTimerPublisher, TimeInterval>
-typealias IntervalMapPublisher = Publishers.Map<IntervalPublisher, TimeInterval>
-
 protocol CountdownPublisherArgsProtocol {
     var countdownFrom: Double { get }
     var referenceTime: TimeInterval { get }
@@ -17,26 +13,31 @@ struct TimerPublishers {
     
     // Creates a publisher (correct term?) for generating intervals suitable for chaining
     // with more operators
-    func intervalPublisher(interval: TimeInterval = defaultInterval) -> IntervalPublisher {
+    func intervalPublisher(interval: TimeInterval = defaultInterval) -> AnyPublisher<TimeInterval, Never> {
         return Timer.publish(every: interval, on: .main, in: .default)
             .autoconnect()
             .map(\.timeIntervalSince1970)
+            .eraseToAnyPublisher()
     }
     
     // Converts interval into elapsedTime (given a starting time `startAt`)
-    func elapsedPublisherClosure(referenceTime: TimeInterval, interval: TimeInterval) -> IntervalMapPublisher {
+    func elapsedPublisherClosure(referenceTime: TimeInterval, interval: TimeInterval) -> AnyPublisher<TimeInterval, Never> {
         return self.intervalPublisher(interval: interval)
             .map({ (timeInterval) in
                 return timeInterval - referenceTime
             })
+            .eraseToAnyPublisher()
     }
     
     // Converts an elapsedTime into a countdown timer, given `countdownFrom`
-    func countdownPublisher(args: CountdownPublisherArgsProtocol) -> IntervalMapPublisher {
+    // Note regarding Double vs TimeInterval. I don't have strong argument for using Double for Countdown it just feels
+    // like the countdown is just a number to me. PS: TimeInterval is a system defined typealias for Double anyway.
+    func countdownPublisher(args: CountdownPublisherArgsProtocol) -> AnyPublisher<Double, Never> {
         let interval = args.interval ?? Self.defaultInterval
         return self.elapsedPublisherClosure(referenceTime: args.referenceTime, interval: interval)
             .map({elapsedTime in
                 return args.countdownFrom - elapsedTime
             })
+            .eraseToAnyPublisher()
     }
 }

--- a/PicIt/View/CameraButton/CameraCaptureButtonView.swift
+++ b/PicIt/View/CameraButton/CameraCaptureButtonView.swift
@@ -45,10 +45,6 @@ struct CameraCaptureButton: View {
                         isRunning: $countdownIsRunning,
                         timer: $timer)
                     
-                    // TODO: Tweak countdownState, need state where timer is ready to restart, but animation is still shown
-                    //       Currently, .ready is the only valid state to start timer, but sometimes we want to show the animation
-                    //       (like when the countdown is paused), but other times we don't (like after it completes)
-                    //       One possible option is to allow stopped and complete to be valid "ready" states.
                         .onReceive(model.$countdownTime) { timer = $0 ?? 0.0 }
                         .onReceive(model.$countdownState) { state in
                             mediaModeView = AnyView(model.mediaMode.indicatorView())
@@ -63,9 +59,14 @@ struct CameraCaptureButton: View {
                                 countdownIsRunning = false
                             case .triggering:
                                 scaleAmount = 2.0
-                            default:
+                            case .ready, .complete:
                                 scaleAmount = 1.0
-                                showCountdownAnimation = true // TODO: Change to false once .stopped does not change to .ready
+                                showCountdownAnimation = false
+                                countdownIsRunning = false
+                            case .undefined, .none:
+                                // TODO: Gray out
+                                scaleAmount = 0.5
+                                showCountdownAnimation = false
                                 countdownIsRunning = false
                             }
                         }

--- a/PicItTests/Model/CountdownTests.swift
+++ b/PicItTests/Model/CountdownTests.swift
@@ -5,28 +5,23 @@ import Combine
 
 @testable import PicIt
 
+// Allows for cleaner func signatures
 typealias Closure<ARG, RET> = (ARG) -> RET
-// typealias ExpectationCompletion = (Subscribers.Completion<Never>) -> Void
 
-// TODO: create new helper function countdown that does not go below 0 ... this will leave the state as .inProgress (so we can test that)
-//       Once we have a couple functions, DRY it up so that we can test various countdown scenarios.
 class CountdownTests: XCTestCase {
         
-    private var countdownBasic: Countdown!
+    private var countdownComplete: Countdown!
     
-    // This value is appended to the countdown, it signals that we've finished all countdown related work
-    // I would MUCH rather use a copletion handler, but haven't figured out how to do that for a published variable
-    // in an ObservableObject.
-//    private static let markEndOfCountdown = -999.0
     private var cancellables: Set<AnyCancellable> = []
     
     override func setUpWithError() throws {
         super.setUp()
         
-        // Setup a basic countdown instance
+        // Setup a countdown instance that can complete a full countdown
         let countdownListBasic = makeCountdownList(interval: MockDefaults.interval, countdownFrom: MockDefaults.countdownFrom)
-        let countdownDependenciesBasic = makeDependencies(countdownListBasic)
-        countdownBasic = Countdown(countdownDependenciesBasic)
+        let mockCompleteCountdown = MockFactory.addEndMarker(countdownListBasic)
+        let countdownDependenciesComplete = makeDependencies(mockCompleteCountdown)
+        countdownComplete = Countdown(countdownDependenciesComplete)
     }
     
     override func tearDownWithError() throws {
@@ -36,36 +31,76 @@ class CountdownTests: XCTestCase {
     // Instantiation Tests
     func test_init_stateIsReady() throws {
         XCTAssertEqual(Countdown().state, .ready) // Test default initialization
-        XCTAssertEqual(countdownBasic.state, .ready)
+        XCTAssertEqual(countdownComplete.state, .ready)
     }
     
     func test_init_timeIsInitialized() throws {
         XCTAssertEqual(Countdown().time, Countdown.initialCountdownTime) // Test default initialization
-        XCTAssertEqual(countdownBasic.time, Countdown.initialCountdownTime)
+        XCTAssertEqual(countdownComplete.time, Countdown.initialCountdownTime)
     }
         
     // countdown behavior tests
+    func test_reset_countdownNeverSubscribed() throws {
+        countdownComplete.reset()
+        XCTAssertEqual(countdownComplete.state, .ready)
+        XCTAssertEqual(countdownComplete.time, Countdown.initialCountdownTime)
+    }
+    
+    func test_reset_countdownCompleted() throws {
+        let expectation = XCTestExpectation(description: "Wait for last countdown value")
+        
+        // Fulfills expecation
+        timeSubscriberWithExpectation(countdownComplete, expectation: expectation)
+        
+        countdownComplete.start()
+        wait(for: [expectation], timeout: 0.1)
+        countdownComplete.reset()
+        
+        XCTAssertEqual(countdownComplete.state, .ready)
+        XCTAssertEqual(countdownComplete.time, Countdown.initialCountdownTime)
+    }
+    
+    func test_reset_countdownStateUndefined() throws {
+        let deps = makeDependencies([])
+        let countdownWithStateUndefined = Countdown(deps, initialState: .undefined)
+        XCTAssertEqual(CountdownState.undefined, countdownWithStateUndefined.state)
+        countdownWithStateUndefined.reset()
+        XCTAssertEqual(countdownWithStateUndefined.state, .ready)
+    }
+    
+    func test_reset_countdownStateValidToReset() throws {
+        let validStates: [CountdownState] = [.inProgress, .triggering, .stopped, .complete]
+        validStates.forEach { state in
+            let deps = makeDependencies([])
+            let countdownWithState = Countdown(deps, initialState: state)
+            XCTAssertEqual(state, countdownWithState.state)
+            countdownWithState.reset()
+            XCTAssertEqual(countdownWithState.state, .ready)
+        }
+    }
+    
     func test_start_timeIsUpdated() throws {
         self.continueAfterFailure = false
         let expectation = XCTestExpectation(description: "Wait for last countdown value")
 
+        // We need access to countdownList to verify publishing countdown time is working
         let countdownList = makeCountdownList(interval: MockDefaults.interval, countdownFrom: MockDefaults.countdownFrom)
         let mockCompleteCountdown = MockFactory.addEndMarker(countdownList)
         let countdownDependencies = makeDependencies(mockCompleteCountdown)
-        let countdown = Countdown(countdownDependencies)
+        let countdownComplete = Countdown(countdownDependencies)
         
         var expectedCountdownTimes = expectedCountdownComplete(countdownList,
                                                                initVal: Countdown.initialCountdownTime,
                                                                endMarker: CountdownTests.markEndOfCountdown)
         
-        timeSubscriberWithExpectation(countdown, expectation: expectation) { time in
+        timeSubscriberWithExpectation(countdownComplete, expectation: expectation) { time in
             // remove elements from the expected array and compare to actual published value
             let expectedCountdownTime = expectedCountdownTimes.isEmpty ? nil : expectedCountdownTimes.removeFirst()
             XCTAssertNotNil(expectedCountdownTime)
             XCTAssertEqual(expectedCountdownTime!, time, accuracy: 0.01) // compare to published value
         }
         
-        countdown.start()
+        countdownComplete.start()
         wait(for: [expectation], timeout: 0.1)
     }
     
@@ -88,7 +123,7 @@ class CountdownTests: XCTestCase {
         }
         
         countdown.$state
-            .removeDuplicates() // Remove duplicates to get unique states chnages
+            .removeDuplicates() // Remove duplicates to get unique state changes
             .sink { state in receivedStates.append(state) }
             .store(in: &cancellables)
         
@@ -118,7 +153,7 @@ class CountdownTests: XCTestCase {
         }
         
         countdown.$state
-            .removeDuplicates() // Remove duplicates to get unique states chnages
+            .removeDuplicates() // Remove duplicates to get unique state changes
             .sink { state in receivedStates.append(state) }
             .store(in: &cancellables)
         
@@ -129,27 +164,24 @@ class CountdownTests: XCTestCase {
     }
     
     func test_start_stateIsUpdatedOnCompleteCountdown() throws {
-        let countdownList = makeCountdownList(interval: MockDefaults.interval, countdownFrom: MockDefaults.countdownFrom)
-        let mockCompleteCountdown = MockFactory.addEndMarker(countdownList)
-        let countdownDependencies = makeDependencies(mockCompleteCountdown)
-        let countdown = Countdown(countdownDependencies)
+        let expectation = XCTestExpectation(description: "Wait for last countdown value")
         
         var receivedStates: [CountdownState] = []
-        let expectation = XCTestExpectation(description: "Wait for last countdown value")
+        
         // TODO: This test is failing, because Countdown behavior needs to change
         let expectedCountdownStates: [CountdownState] = [.ready, .inProgress, .triggering, .complete]
   
         // Fulfills expecation
-        timeSubscriberWithExpectation(countdown, expectation: expectation)
+        timeSubscriberWithExpectation(countdownComplete, expectation: expectation)
         
-        countdown.$state
+        countdownComplete.$state
             .removeDuplicates() // Remove duplicates to get unique states chnages
             .sink { state in
             receivedStates.append(state)
         }
         .store(in: &cancellables)
         
-        countdown.start()
+        countdownComplete.start()
         wait(for: [expectation], timeout: 0.1)
         
         XCTAssertEqual(expectedCountdownStates, receivedStates)
@@ -158,12 +190,19 @@ class CountdownTests: XCTestCase {
         print("Received: \(String(describing: receivedStates))")
     }
     
-    func test_reset_countdownNeverSubscribed() throws {
-        countdownBasic.reset()
-        XCTAssertEqual(countdownBasic.state, .ready)
-        XCTAssertEqual(countdownBasic.time, Countdown.initialCountdownTime)
+    func test_stop() throws {
+        countdownComplete.stop()
+        XCTAssertEqual(countdownComplete.state, .stopped)
     }
-         
+
+    func test_complete() throws {
+        countdownComplete.complete()
+        XCTAssertEqual(countdownComplete.state, .complete)
+    }
+}
+
+// Helpers for setting up a Subscriber to exercise the observable
+extension CountdownTests {
     private func timeSubscriber(_ countdown: Countdown, perform: Closure<Double, Void>? = nil) {
         countdown.$time.sink { time in
             perform?(time)
@@ -201,7 +240,7 @@ extension CountdownTests {
         wrappedList.append(endMarker)
         return wrappedList
     }
-    
+        
     struct MockDefaults {
         static let referenceTimeClosure = { Date(timeIntervalSinceReferenceDate: 0.0).timeIntervalSince1970}
         static let countdownFrom = 5.5
@@ -210,6 +249,9 @@ extension CountdownTests {
 
     struct MockFactory {
         
+        // Appends a magic number to the countdown, it signals that we've finished all countdown related work
+        // I would MUCH rather use a combine completion handler, but haven't figured out how to do that for a published property
+        // in an ObservableObject.
         static func addEndMarker(_ countdownList: [Double]) -> [Double] {
             return countdownList + [CountdownTests.markEndOfCountdown]
         }
@@ -235,13 +277,8 @@ extension CountdownTests {
             )
         }
 
-        
         static func countdownClosure(_ countdownList: [Double]) -> CountdownPublisherClosure {
             return { _ in countdownList.publisher.eraseToAnyPublisher() }
         }
-        
-//        static func countdownPublishedListComplete(_ countdownList: [Double]) -> [Double] {
-//            return wrapCountdownList(countdownList, initVal: Countdown.initialCountdownTime, endMarker: CountdownTests.markEndOfCountdown)
-//        }
     }
 }

--- a/PicItTests/Model/CountdownTests.swift
+++ b/PicItTests/Model/CountdownTests.swift
@@ -1,20 +1,247 @@
 //
 
 import XCTest
+import Combine
 
 @testable import PicIt
 
+typealias Closure<ARG, RET> = (ARG) -> RET
+// typealias ExpectationCompletion = (Subscribers.Completion<Never>) -> Void
+
+// TODO: create new helper function countdown that does not go below 0 ... this will leave the state as .inProgress (so we can test that)
+//       Once we have a couple functions, DRY it up so that we can test various countdown scenarios.
 class CountdownTests: XCTestCase {
+        
+    private var countdownBasic: Countdown!
     
-    private var countdown: Countdown!
+    // This value is appended to the countdown, it signals that we've finished all countdown related work
+    // I would MUCH rather use a copletion handler, but haven't figured out how to do that for a published variable
+    // in an ObservableObject.
+//    private static let markEndOfCountdown = -999.0
+    private var cancellables: Set<AnyCancellable> = []
     
     override func setUpWithError() throws {
         super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-        countdown = Countdown()
+        
+        // Setup a basic countdown instance
+        let countdownListBasic = makeCountdownList(interval: MockDefaults.interval, countdownFrom: MockDefaults.countdownFrom)
+        let countdownDependenciesBasic = makeDependencies(countdownListBasic)
+        countdownBasic = Countdown(countdownDependenciesBasic)
+    }
+    
+    override func tearDownWithError() throws {
+        cancellables = []
+    }
+    
+    // Instantiation Tests
+    func test_init_stateIsReady() throws {
+        XCTAssertEqual(Countdown().state, .ready) // Test default initialization
+        XCTAssertEqual(countdownBasic.state, .ready)
+    }
+    
+    func test_init_timeIsInitialized() throws {
+        XCTAssertEqual(Countdown().time, Countdown.initialCountdownTime) // Test default initialization
+        XCTAssertEqual(countdownBasic.time, Countdown.initialCountdownTime)
     }
         
-    func testInstanceCreatedInReadyState() throws {
-        XCTAssertEqual(countdown.state, .ready)
+    // countdown behavior tests
+    func test_start_timeIsUpdated() throws {
+        self.continueAfterFailure = false
+        let expectation = XCTestExpectation(description: "Wait for last countdown value")
+
+        let countdownList = makeCountdownList(interval: MockDefaults.interval, countdownFrom: MockDefaults.countdownFrom)
+        let mockCompleteCountdown = MockFactory.addEndMarker(countdownList)
+        let countdownDependencies = makeDependencies(mockCompleteCountdown)
+        let countdown = Countdown(countdownDependencies)
+        
+        var expectedCountdownTimes = expectedCountdownComplete(countdownList,
+                                                               initVal: Countdown.initialCountdownTime,
+                                                               endMarker: CountdownTests.markEndOfCountdown)
+        
+        timeSubscriberWithExpectation(countdown, expectation: expectation) { time in
+            // remove elements from the expected array and compare to actual published value
+            let expectedCountdownTime = expectedCountdownTimes.isEmpty ? nil : expectedCountdownTimes.removeFirst()
+            XCTAssertNotNil(expectedCountdownTime)
+            XCTAssertEqual(expectedCountdownTime!, time, accuracy: 0.01) // compare to published value
+        }
+        
+        countdown.start()
+        wait(for: [expectation], timeout: 0.1)
+    }
+    
+    func test_start_stateInProgress() throws {
+        let countdownList = [MockDefaults.countdownFrom]
+        let countdownDependencies = makeDependencies(countdownList)
+        let countdown = Countdown(countdownDependencies)
+        
+        var receivedStates: [CountdownState] = []
+        let expectation = XCTestExpectation(description: "Get first countdown event")
+        // TODO: This test is failing, because Countdown behavior needs to change
+        let expectedCountdownStates: [CountdownState] = [.ready, .inProgress]
+  
+        // Fulfills expecation
+        timeSubscriber(countdown) { time in
+            print("Countdown time: \(time)")
+            if time == MockDefaults.countdownFrom {
+                expectation.fulfill()
+            }
+        }
+        
+        countdown.$state
+            .removeDuplicates() // Remove duplicates to get unique states chnages
+            .sink { state in receivedStates.append(state) }
+            .store(in: &cancellables)
+        
+        countdown.start()
+        wait(for: [expectation], timeout: 0.1)
+        
+        XCTAssertEqual(expectedCountdownStates, receivedStates)
+    }
+    
+    func test_start_stateTriggering() throws {
+        let triggerValue = 0.0 // must be <= 0
+        let countdownList = [MockDefaults.countdownFrom, triggerValue]
+        let countdownDependencies = makeDependencies(countdownList)
+        let countdown = Countdown(countdownDependencies)
+        
+        var receivedStates: [CountdownState] = []
+        let expectation = XCTestExpectation(description: "Wait until triggering")
+        // TODO: This test is failing, because Countdown behavior needs to change
+        let expectedCountdownStates: [CountdownState] = [.ready, .inProgress, .triggering]
+  
+        // Fulfills expecation
+        timeSubscriber(countdown) { time in
+            print("Countdown time: \(time)")
+            if time == triggerValue {
+                expectation.fulfill()
+            }
+        }
+        
+        countdown.$state
+            .removeDuplicates() // Remove duplicates to get unique states chnages
+            .sink { state in receivedStates.append(state) }
+            .store(in: &cancellables)
+        
+        countdown.start()
+        wait(for: [expectation], timeout: 0.1)
+        
+        XCTAssertEqual(expectedCountdownStates, receivedStates)
+    }
+    
+    func test_start_stateIsUpdatedOnCompleteCountdown() throws {
+        let countdownList = makeCountdownList(interval: MockDefaults.interval, countdownFrom: MockDefaults.countdownFrom)
+        let mockCompleteCountdown = MockFactory.addEndMarker(countdownList)
+        let countdownDependencies = makeDependencies(mockCompleteCountdown)
+        let countdown = Countdown(countdownDependencies)
+        
+        var receivedStates: [CountdownState] = []
+        let expectation = XCTestExpectation(description: "Wait for last countdown value")
+        // TODO: This test is failing, because Countdown behavior needs to change
+        let expectedCountdownStates: [CountdownState] = [.ready, .inProgress, .triggering, .complete]
+  
+        // Fulfills expecation
+        timeSubscriberWithExpectation(countdown, expectation: expectation)
+        
+        countdown.$state
+            .removeDuplicates() // Remove duplicates to get unique states chnages
+            .sink { state in
+            receivedStates.append(state)
+        }
+        .store(in: &cancellables)
+        
+        countdown.start()
+        wait(for: [expectation], timeout: 0.1)
+        
+        XCTAssertEqual(expectedCountdownStates, receivedStates)
+        
+        print("Expected: \(String(describing: expectedCountdownStates))")
+        print("Received: \(String(describing: receivedStates))")
+    }
+    
+    func test_reset_countdownNeverSubscribed() throws {
+        countdownBasic.reset()
+        XCTAssertEqual(countdownBasic.state, .ready)
+        XCTAssertEqual(countdownBasic.time, Countdown.initialCountdownTime)
+    }
+         
+    private func timeSubscriber(_ countdown: Countdown, perform: Closure<Double, Void>? = nil) {
+        countdown.$time.sink { time in
+            perform?(time)
+        }
+        .store(in: &cancellables)
+    }
+    
+    private func timeSubscriberWithExpectation(_ countdown: Countdown, expectation: XCTestExpectation, perform: Closure<Double, Void>? = nil ) {
+        timeSubscriber(countdown) { time in
+            perform?(time)
+            if time == Self.markEndOfCountdown {
+                expectation.fulfill()
+            }
+        }
+    }
+}
+
+// Test Helpers for setting up mocks
+extension CountdownTests {
+    private static let markEndOfCountdown = -999.0
+    
+    func makeCountdownList(interval: TimeInterval, countdownFrom: Double) -> [Double] {
+        let step = -interval
+        return Array(stride(from: countdownFrom, through: step, by: step))
+    }
+    
+    func makeDependencies(_ countdownList: [Double]) -> CountdownDependencies {
+        let countdownPublisherClosure = MockFactory.countdownClosure(countdownList)
+        return MockFactory.getCountdownDependencies(countdownPublisherClosure)
+    }
+    
+    func expectedCountdownComplete(_ countdownList: [Double], initVal: Double, endMarker: Double) -> [Double] {
+        var wrappedList = countdownList
+        wrappedList.insert(initVal, at: 0)
+        wrappedList.append(endMarker)
+        return wrappedList
+    }
+    
+    struct MockDefaults {
+        static let referenceTimeClosure = { Date(timeIntervalSinceReferenceDate: 0.0).timeIntervalSince1970}
+        static let countdownFrom = 5.5
+        static let interval = 0.7
+    }
+
+    struct MockFactory {
+        
+        static func addEndMarker(_ countdownList: [Double]) -> [Double] {
+            return countdownList + [CountdownTests.markEndOfCountdown]
+        }
+
+        static func getCountdownDependencies(_ countdownPublisherClosure: @escaping CountdownPublisherClosure,
+                                             referenceTimeProvider: @escaping ReferenceTimeProvider = MockDefaults.referenceTimeClosure,
+                                             countdownFrom: Double = MockDefaults.countdownFrom,
+                                             interval: TimeInterval = MockDefaults.interval
+        ) -> CountdownDependencies {
+            return CountdownDependencies(
+                referenceTimeProvider: referenceTimeProvider,
+                countdownFrom: countdownFrom,
+                interval: interval,
+                countdownPublisherClosure: countdownPublisherClosure
+            )
+        }
+
+        static func getCountdownPublisherArgs(_ deps: CountdownDependenciesProtocol) -> CountdownPublisherArgsProtocol {
+            return CountdownPublisherArgs(
+                countdownFrom: deps.countdownFrom,
+                referenceTime: deps.referenceTimeProvider(),
+                interval: deps.interval
+            )
+        }
+
+        
+        static func countdownClosure(_ countdownList: [Double]) -> CountdownPublisherClosure {
+            return { _ in countdownList.publisher.eraseToAnyPublisher() }
+        }
+        
+//        static func countdownPublishedListComplete(_ countdownList: [Double]) -> [Double] {
+//            return wrapCountdownList(countdownList, initVal: Countdown.initialCountdownTime, endMarker: CountdownTests.markEndOfCountdown)
+//        }
     }
 }

--- a/PicItTests/Model/CountdownTests.swift
+++ b/PicItTests/Model/CountdownTests.swift
@@ -1,0 +1,20 @@
+//
+
+import XCTest
+
+@testable import PicIt
+
+class CountdownTests: XCTestCase {
+    
+    private var countdown: Countdown!
+    
+    override func setUpWithError() throws {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        countdown = Countdown()
+    }
+        
+    func testInstanceCreatedInReadyState() throws {
+        XCTAssertEqual(countdown.state, .ready)
+    }
+}

--- a/README.MD
+++ b/README.MD
@@ -27,8 +27,10 @@ Modified from the open sourced (MIT Licensed) [SwiftCamera](https://github.com/r
 
 ## General Learnings
 * SwiftUI development
-  * Using Observables and reactive programming techniques (I was already familiar with reactive programming)
+  * Using Combine Observables and reactive programming techniques (I was already familiar with reactive programming)
   * Managing view state, and inter-view communication
+* SwiftUI Testing (XCTest)
+  * Testing Combine, specifically using XCTestExpectation
 
 ## Tap on Thumbnail
 
@@ -55,7 +57,7 @@ Unfortunately, one consequence of deleting was that returning to the main app sc
 ## Timer Publisher
 
 Still work in progress. Started with Timer in view, moved it to a model, but the original model was very basic and monolithic. Essentially it could only do countdowns.
-Current model has split out the various timer observal logic into a separate file/struct: `TimerPublishers.swift`. The observables in `TimerPublishers` have been decomposed into basic building blocks:
+Current model has split out the various timer observable logic into a separate file/struct: `TimerPublishers.swift`. The observables in `TimerPublishers` have been decomposed into basic building blocks:
 * `intervalPublisher`: An observable that publishes a unix timestamp on a given interval (thin wrapper around combine's `Timer.Publish`)
 * `elapsedPublisherClosure`: A closure that returns an observable that provides the elapsedTime given the start time at periodic intervals (intervals come from `intervalPublisher`)
 * `countdownPublisher`: An observable that generates a countdown given a the countdown to start from and a time the countdown started (usually immediate). Uses `elapsedPUblisherClosure`. 
@@ -92,3 +94,47 @@ class Foo {
 ```
 
 I'd be happier if I could figure out an elegant way to skip the `<Foo>` generics, but I'm not sure it's possible given that typing is static at compile time.
+
+## Style Preferences
+
+### Type Aliasing for Closures
+
+#### Prefer type alias for closures
+
+Generic Closure
+```swift
+typealias Closure<ARG, RET> = (ARG) -> RET
+
+...
+
+let foo: Closure<Double, Int>
+```
+
+Closures without arguments
+```swift
+typealias NoArgClosure<T> = () -> T
+
+...
+
+let foo: NoArgClosure<Void>
+
+
+# Optional (I'm not currently doing this, as I think NoArgClosure<Void> is sufficiently concise and readable )
+typealias VoidClosure = () -> Void
+let foo: VoidClosure
+```
+
+#### No arrows in argument types
+Keep func signatures clean with type aliasing. This is somewhat repetitive to the above, but reiterated because I abhor complicated typing inline with function declarations.
+
+Don't do this
+```swift
+func foo(fooArgs: (closureBarArgs: BarArgsType) -> BarReturnType) -> FooReturnType { ... }
+```
+
+Do this instead:
+```swift
+typealias BarClosure = (BarArgsType) -> BarReturnType
+...
+func foo(fooArgs: BarClosure) -> FooReturnType { ... }
+```


### PR DESCRIPTION
In addition to the Countdown tests
    * injected initial countdown state for easier testability
    * reset() now resets the countdown time too
    * Remove countdown sweeper when countdown is finished
    * Centralized setting Countdown state
    * Updated View to reflect the correct Countdown state

Also, testing uncovered other improvements to make:
    CameraModel
    * rename countdownPublisher -> countdownPublisherClosure to better reflect that it returns a publisher, but is n
ot a publisher in and of itself.

    Countdown
    * Moved main thread wrapper out of the Countdown service and into CameraModel, it had no business being there.
    * Moved initial time property to come from static constant, rather than number. This helps with testing too.
    * Removed unnecessary .undefined setting, as it was being overridden on initialization (so it was never set to .
undefined to begin with)
    * Renamed defaults -> dependencies, as they are being injected so not really default values anymore.
    * Refactored updateStateFromTimer to ensure intermediate states are assigned properly and all states are covered
 when the countdown ends
